### PR TITLE
Revert "Default decimals to 18"

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Define a new lrc-20.
 | op     | yes      | string     | Operation: `"deploy"`                                                         |
 | tick   | yes      | string     | Ticker: 4-letter identifier of the lrc-20                                     |
 | max    | yes      | number     | Max supply: Total number of tokens to be minted                               |
-| dec    | no       | number     | Decimals: Decimal shift for display. Defaults to 18.                           |
+| dec    | no       | number     | Decimals: Decimal shift for display. Defaults to 0.                           |
 | lim    | yes      | number     | Mint limit: Limit on tokens minted per user mint operation                    |
 | sats   | yes      | number     | Lock amount: Minimum amount of satoshis locked to be a valid mint             |
 | blocks | yes      | number     | Lock blocks: Minimum number of blocks locked to be a valid mint  		     |


### PR DESCRIPTION
Reverts shrdlu2/lrc-20#1

After some discussion, it doesn't make sense to change this alone.

LRC-20 uses integers to store amounts and decimals as a shift for display. Like ERC-20 and others.

BRC-20 uses [decimal numbers](https://github.com/unisat-wallet/libbrc20-indexer/blob/main/decimal/decimal.go#L32) for amounts and decimals is how many digits right of the decimal there can be.

Changing LRC-20 decimals default to 18 now would mean $hodl supply becomes 0.000000000021, so this change would also need to come with a new meaning for decimals and spec for the decimals numbers.

I'm open to it, but that's a bigger change than just changing the default and could break other tokens. Needs to be looked into more.